### PR TITLE
setup script fix/improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ terraform destroy -var-file=env/dev.tfvars -target=module.prometheus.helm_releas
 ## Troubleshooting
 In case of errors related to missing kubernetes provider in terraform - please try to reauthenticate:
 ```
-gcloud container clusters get-credentials tbd-gke-cluster --zone ${TF_VAR_location} --project ${TF_VAR_project_name}
+gcloud container clusters get-credentials tbd-gke-cluster --zone ${TF_VAR_zone} --project ${TF_VAR_project_name}
 ```
 
 ## Monitoring K8s and Spark applications

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ bin/create-project.sh
 #setup GKE and install necessary components
 terraform init  
 #observe your infra DAG
-terraform plan -var-file=env/dev.tfvars -var 'max_node_count=10'
+terraform plan -var-file=env/dev.tfvars -var 'max_node_count=10' -out plan
 #deploy it if you fully understand the execution plan displayed!
 # Warning!: Time needed for cluster setup: approx. 10 mins
-terraform apply -var-file=env/dev.tfvars -var 'max_node_count=10'
+terraform apply "plan"
 ```
 
 ## Connect to GKE cluster
@@ -127,7 +127,7 @@ Use `admin` as username and get admin password
 ```
 #get admin user password
 kubectl get secret prometheus-community-grafana -o jsonpath='{.data}' -n default \
-| jq -r '."admin-password"' | base64 --decode
+| jq -r '."admin-password"' | base64 --decode && echo ' '
 ```
 
 ## Import grafana dashboards


### PR DESCRIPTION
1. Fix

Added `-out plan` to terraform plan init and changed the terraform apply to use the initialized plan.
It wouldn't let me proceed without doing that. Fix done according to terraform warning/error messages

2. Enhancement

Added `&& echo ' '` so that the password is printed in a separate line from the current terminal path

example: 
```
root@ec05666c972b:/home/tbd/git/tbd-infra# kubectl get secret prometheus-community-grafana -o jsonpath='{.data}' -n default | jq -r '."admin-password"' | base64 --decode
prom-operatorroot@ec05666c972b:/home/tbd/git/tbd-infra#
root@ec05666c972b:/home/tbd/git/tbd-infra# kubectl get secret prometheus-community-grafana -o jsonpath='{.data}' -n default | jq -r '."admin-password"' | base64 --decode && echo ' '
prom-operator
root@ec05666c972b:/home/tbd/git/tbd-infra#
```
